### PR TITLE
allow unsigned vagrant rpm

### DIFF
--- a/openSUSE_vagrant_setup.sh
+++ b/openSUSE_vagrant_setup.sh
@@ -1,7 +1,7 @@
 set -ex
 
 #install vagrant and it dependencies, devel files to build vagrant plugins later
-zypper in -y https://releases.hashicorp.com/vagrant/2.0.3/vagrant_2.0.3_x86_64.rpm 
+zypper in -y --allow-unsigned-rpm https://releases.hashicorp.com/vagrant/2.0.3/vagrant_2.0.3_x86_64.rpm
 zypper in -y ruby-devel
 zypper in -y gcc gcc-c++ make
 zypper in -y qemu-kvm libvirt-daemon-qemu libvirt libvirt-devel


### PR DESCRIPTION
zypper -y automatically selects the default value when a user choice
is required. This breaks the vagrant rpm installation since the rpm
is unsigned and the default selection is to abort installation.