### PR TITLE
Revert "allow unsigned vagrant rpm"

### DIFF
--- a/openSUSE_vagrant_setup.sh
+++ b/openSUSE_vagrant_setup.sh
@@ -1,7 +1,7 @@
 set -ex
 
 #install vagrant and it dependencies, devel files to build vagrant plugins later
-zypper in -y --allow-unsigned-rpm https://releases.hashicorp.com/vagrant/2.0.3/vagrant_2.0.3_x86_64.rpm
+zypper in -y https://releases.hashicorp.com/vagrant/2.0.3/vagrant_2.0.3_x86_64.rpm 
 zypper in -y ruby-devel
 zypper in -y gcc gcc-c++ make
 zypper in -y qemu-kvm libvirt-daemon-qemu libvirt libvirt-devel


### PR DESCRIPTION
Reverts openSUSE/vagrant-ceph#21 as fails in the testing:

++ zypper in -y --allow-unsigned-rpm https://releases.hashicorp.com/vagrant/2.0.3/vagrant_2.0.3_x86_64.rpm
Unknown option '--allow-unsigned-rpm'

http://storage-ci.suse.de:8080/job/vagrant-ceph-run/12/console