### PR TITLE
boxes: Use box from Devel:Storage:5 for SLE12SP3

### DIFF
--- a/boxes/sle12-sp3.x86_64-0.0.1.libvirt.json
+++ b/boxes/sle12-sp3.x86_64-0.0.1.libvirt.json
@@ -6,7 +6,7 @@
          "providers" : [
             {
                "name" : "libvirt",
-               "url" : "http://download.suse.de/ibs/home:/dkondratenko:/images:/vagrant/vagrant/sle12-sp3.x86_64.libvirt.box"
+               "url" : "http://download.suse.de/ibs/Devel:/Storage:/5.0/vagrant/sle12-sp3.x86_64.libvirt.box"
             }
          ],
          "version" : "0.0.1"

--- a/config.yml
+++ b/config.yml
@@ -297,8 +297,6 @@ SUSE/SLE-12-SP3:
         - chown -R salt:salt /srv/pillar/ceph /srv/salt/ceph 
         - chmod 1777 /tmp
       all:
-        - systemctl disable SuSEfirewall2
-        - systemctl stop SuSEfirewall2
         - systemctl restart salt-minion
         - systemctl enable salt-minion
 


### PR DESCRIPTION
I tested the new image from Devel:Storage:5.0 and it seems to work fine. We could remove the stopping of SuSEfirewall, as this package isn't installed to the base image anymore...