### PR TITLE
Add out-of-the box configuration for SLE-15-SP1 tiny setup

### DIFF
--- a/files/salt/SLE-15-SP1_tiny/srv/pillar/ceph/deepsea_minions.sls
+++ b/files/salt/SLE-15-SP1_tiny/srv/pillar/ceph/deepsea_minions.sls
@@ -1,0 +1,1 @@
+deepsea_minions: '*'

--- a/files/salt/SLE-15-SP1_tiny/srv/pillar/ceph/proposals/policy.cfg
+++ b/files/salt/SLE-15-SP1_tiny/srv/pillar/ceph/proposals/policy.cfg
@@ -1,0 +1,20 @@
+# Cluster assignment
+cluster-ceph/cluster/*.sls
+#cluster-unassigned/cluster/client*.sls
+# Hardware Profile
+profile-*/cluster/data*.sls
+profile-*/stack/default/ceph/minions/data*.yml
+# Common configuration
+config/stack/default/global.yml
+config/stack/default/ceph/cluster.yml
+# Role assignment
+role-master/cluster/admin*.sls
+role-admin/cluster/data[1,2,3]*.sls
+role-igw/cluster/data3*.sls
+role-igw/stack/default/ceph/minions/data3*.yml
+role-rgw/cluster/data2*.sls
+role-mon/cluster/data[1,2,3]*.sls
+role-mon/stack/default/ceph/minions/data[1,2,3]*.yml
+role-mgr/cluster/mon*.sls
+role-mds/cluster/data1*.sls
+#role-openattic/cluster/mon[1,2]*.sls

--- a/files/salt/SLE-15-SP1_tiny/srv/pillar/ceph/stack/global.yml
+++ b/files/salt/SLE-15-SP1_tiny/srv/pillar/ceph/stack/global.yml
@@ -1,0 +1,5 @@
+# Customizations for /srv/pillar/ceph/stack/global.yml
+DEV_ENV: True
+#stage_prep_minion: default-update-no-reboot
+#stage_prep_master: default-update-no-reboot
+


### PR DESCRIPTION
This PR contains the necessary DeepSea configuration to start deploying right after creating the cluster.

Signed-off-by: Volker Theile <vtheile@suse.com>