### PR TITLE
Unify config

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -45,7 +45,7 @@ opensuse/openSUSE-Tumbleweed-x86_64:
         - systemctl enable ntpd
         - systemctl start salt-master
         - systemctl enable salt-master
-        - sleep 10
+        - sleep 20
         - salt-key -y -A  || exit 0
         - sleep 5
         # https://github.com/SUSE/DeepSea/issues/309
@@ -88,7 +88,7 @@ opensuse/openSUSE-15.0-x86_64:
       admin:
         - systemctl start salt-master
         - systemctl enable salt-master
-        - sleep 5
+        - sleep 20
         - salt-key -y -A  || exit 0
         - chown -R salt:salt /srv/pillar/ceph /srv/salt/ceph
       all:
@@ -125,7 +125,7 @@ opensuse/openSUSE-42.3-x86_64:
         - systemctl enable ntpd
         - systemctl start salt-master
         - systemctl enable salt-master
-        - sleep 10
+        - sleep 20
         - salt-key -y -A  || exit 0
         - sleep 5
         - chown -R salt:salt /srv/salt/ceph
@@ -158,7 +158,7 @@ opensuse/openSUSE-42.2-x86_64:
         - systemctl enable ntpd
         - systemctl start salt-master
         - systemctl enable salt-master
-        - sleep 10
+        - sleep 20
         - salt-key -y -A  || exit 0
       all:
         - systemctl disable SuSEfirewall2
@@ -288,7 +288,7 @@ SUSE/SLE-12-SP3:
         - systemctl enable ntpd
         - systemctl start salt-master
         - systemctl enable salt-master
-        - sleep 10
+        - sleep 20
         - salt-key -y -A  || exit 0
         - sleep 5
         - chown -R salt:salt /srv/pillar/ceph /srv/salt/ceph
@@ -324,7 +324,7 @@ SUSE/SLE-15-SP1:
       admin:
         - systemctl start salt-master
         - systemctl enable salt-master
-        - sleep 5
+        - sleep 20
         - salt-key -y -A  || exit 0
         - chown -R salt:salt /srv/pillar/ceph /srv/salt/ceph
       all:
@@ -400,7 +400,7 @@ SLE12-SP2:
         - systemctl enable ntpd
         - systemctl start salt-master
         - systemctl enable salt-master
-        - sleep 10
+        - sleep 20
         - salt-key -y -A  || exit 0
         - chown -R salt:salt /srv/pillar/ceph /srv/salt/ceph
         - chmod 1777 /tmp
@@ -441,7 +441,7 @@ SLE12-SP3-qa:
         - systemctl enable ntpd
         - systemctl start salt-master
         - systemctl enable salt-master
-        - sleep 10
+        - sleep 20
         - salt-key -y -A  || exit 0
         - chown -R salt:salt /srv/pillar/ceph /srv/salt/ceph
         - chmod 1777 /tmp


### PR DESCRIPTION
    config.yml: Unify sleep before salt-key accept
    
    When setting up a ceph cluster in a slower machine, salt-minions could
    take more time to request the keys to master. In order to make this
    process more reliable, change the sleep to 20 to all config entries,
    rather having custom values for different configurations.
    
    Signed-off-by: Marcos Paulo de Souza <mpdesouza@suse.de>