### PR TITLE
adding support for the Kubic

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,14 @@ Next, add the vagrant box.  Choose the box you wish to use from the boxes subdir
 `$ ls boxes/`
 
 <pre>
+Kubic_kubeadm.x86_64.libvirt.json
+Kubic_MicroOS.x86_64.libvirt.json
 openSUSE-13.2.x86_64-1.13.2.libvirt-Build21.39.json
 openSUSE-13.2.x86_64-1.13.2.virtualbox-Build21.39.json
+sle12-sp3.x86_64-0.0.1.libvirt.json
 SLE-12.x86_64-1.12.0.libvirt-Build6.25.json
 SLE-12.x86_64-1.12.0.virtualbox-Build6.25.json
+sle15sp1.x86_64-0.0.1.libvirt.json
 Tumbleweed.x86_64-1.13.2.libvirt-Build2.34.json
 Tumbleweed.x86_64-1.13.2.virtualbox-Build2.34.json
 </pre>
@@ -84,8 +88,8 @@ For instance, add the openSUSE box for libvirt with the following
 Edit the _Vagrantfile_ and set BOX, INSTALLATION and CONFIGURATION.  Use the following for an initial test.
 
 `BOX = 'openSUSE-13.2'` <br>
-`INSTALLATION = 'ceph-deploy'` <br>
-`CONFIGURATION = 'small'` <br>
+
+Or you could specify BOX as an environment `$ BOX="openSUSE-13.2" vagrant up` / `$ export BOX="openSUSE-13.2"`
 
 Start the environment.
 
@@ -148,6 +152,8 @@ For the sake of completeness and stating the obvious, the private ssh key is onl
 The ceph-deploy installation option does not automatically install ceph.  The environment is created to allow the running of ceph-deploy.  For automatic installation, compare the salt installation option. 
 
 The default root password is 'vagrant'.
+
+Kubic boxes have some hardcoded default names, so it could get kubeadm box for admin node and MicroOS for all other nodes. You can specify some `export BOX="opensuse/openSUSE-Tumbleweed-Kubic"` and it will expect `opensuse/openSUSE-Tumbleweed-Kubic-kubeadm-cri-o` and `opensuse/openSUSE-Tumbleweed-Kubic-MicroOS-cri-o` boxes to exist.
 
 ## CI
 There couple of Jenkins CI jobs currently running:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -116,6 +116,11 @@ Vagrant.configure("2") do |vconfig|
     vm_name = PREFIX + name
 
     vconfig.vm.define vm_name do |node|
+
+      if BOX.include?('Kubic')
+        node.vm.box = 'opensuse/openSUSE-Tumbleweed-Kubic-MicroOS-cri-o'
+      end
+
       common_settings(node, config, name)
 
       node.vm.provider :libvirt do |l|
@@ -137,6 +142,11 @@ Vagrant.configure("2") do |vconfig|
   vm_name = PREFIX + "admin"
 
   vconfig.vm.define vm_name do |node|
+
+      if BOX.include?('Kubic')
+        node.vm.box = 'opensuse/openSUSE-Tumbleweed-Kubic-kubeadm-cri-o'
+      end
+
     common_settings(node, config, name)
 
     node.vm.provider :libvirt do |l|
@@ -150,6 +160,4 @@ Vagrant.configure("2") do |vconfig|
     provisioning(hosts, node, config, name)
 
   end
-   
 end
-

--- a/boxes/Kubic_MicroOS.x86_64.libvirt.json
+++ b/boxes/Kubic_MicroOS.x86_64.libvirt.json
@@ -1,0 +1,15 @@
+{
+   "description" : "openSUSE Tumbleweed Kubic MicroOS vagrant box",
+   "name" : "opensuse/openSUSE-Tumbleweed-Kubic-MicroOS-cri-o",
+   "versions" : [
+      {
+         "providers" : [
+            {
+               "name" : "libvirt",
+               "url" : "https://download.opensuse.org/repositories/openSUSE:/Factory:/Images/images/openSUSE_Tumbleweed/openSUSE-Tumbleweed-Kubic.x86_64-15.0-MicroOS-cri-o-Vagrant-x86_64.vagrant.libvirt.box"
+            }
+         ],
+         "version" : "0.0.1"
+      }
+   ]
+}

--- a/boxes/Kubic_kubeadm.x86_64.libvirt.json
+++ b/boxes/Kubic_kubeadm.x86_64.libvirt.json
@@ -1,0 +1,15 @@
+{
+   "description" : "openSUSE Tumbleweed Kubic kubeadm vagrant box",
+   "name" : "opensuse/openSUSE-Tumbleweed-Kubic-kubeadm-cri-o",
+   "versions" : [
+      {
+         "providers" : [
+            {
+               "name" : "libvirt",
+               "url" : "https://download.opensuse.org/repositories/openSUSE:/Factory:/Images/images/openSUSE_Tumbleweed/openSUSE-Tumbleweed-Kubic.x86_64-15.0-kubeadm-cri-o-Vagrant-x86_64.vagrant.libvirt.box"
+            }
+         ],
+         "version" : "0.0.1"
+      }
+   ]
+}

--- a/config.yml
+++ b/config.yml
@@ -59,6 +59,29 @@ opensuse/openSUSE-Tumbleweed-x86_64:
         - systemctl enable salt-minion
 
 ########################################
+# OpenSUSE Tumbleweed
+########################################
+opensuse/openSUSE-Tumbleweed-Kubic:
+  salt:
+    repos:
+    packages:
+      all:
+      admin:
+    files:
+      all: false
+      admin: false
+    commands:
+      admin:
+        - getent hosts admin-management | awk '{ print $1}' | xargs kubeadm init --cri-socket=/var/run/crio/crio.sock --pod-network-cidr=10.244.0.0/16 --token 56fa9a.705a6001db6a6756 --skip-token-print --apiserver-advertise-address 
+        - mkdir -p $HOME/.kube; cp -i /etc/kubernetes/admin.conf $HOME/.kube/config; chown $(id -u):$(id -g) $HOME/.kube/config
+        - kubectl apply -f https://0y.at/kubicflannel
+        - kubectl taint nodes admin node-role.kubernetes.io/master::NoSchedule-
+        - curl -LkSs https://api.github.com/repos/SUSE/rook/tarball/suse-master -o /home/vagrant/rook.tar.gz
+        - tar -xzf /home/vagrant/rook.tar.gz -C /home/vagrant
+      all:
+        - ( ( if [ "$HOSTNAME" != "admin" ]; then kubeadm join --token 56fa9a.705a6001db6a6756 --discovery-token-unsafe-skip-ca-verification admin-management:6443 >>/home/vagrant/join 2>&1; fi; ) & )
+
+########################################
 # OpenSUSE Leap 15
 ########################################
 opensuse/openSUSE-15.0-x86_64:

--- a/lib/provisions.rb
+++ b/lib/provisions.rb
@@ -28,7 +28,9 @@ module Vagrant
 
     # Runs all the commands in a single shell
     def add
-      @node.vm.provision 'shell', inline: @cmds.join('; ') 
+      unless @cmds.empty? then
+        @node.vm.provision 'shell', inline: @cmds.join('; ') 
+      end
     end
   end
 
@@ -45,7 +47,9 @@ module Vagrant
     end
 
     def add
-      @node.vm.provision 'shell', inline: @cmds.join('; ') 
+      unless @cmds.empty? then
+        @node.vm.provision 'shell', inline: @cmds.join('; ')
+      end
     end
   end
 
@@ -70,8 +74,10 @@ module Vagrant
 
     # Runs necessary zypper command, automatically trust repo
     def install_all
-      cmd = "zypper --gpg-auto-import-keys -n in #{@packages['all'].join(' ')}"
-      @node.vm.provision 'shell', inline: cmd
+      unless (@packages['all'].nil?) then
+        cmd = "zypper --gpg-auto-import-keys -n in #{@packages['all'].join(' ')}"
+        @node.vm.provision 'shell', inline: cmd
+      end
     end
 
     # Runs necessary zypper command, automatically trust repo
@@ -116,7 +122,7 @@ module Vagrant
     # Log into each machine and accept which generates the known_hosts
     def authorize
       @servers.each do |server|
-        cmd = "ssh -oStrictHostKeyChecking=no #{server} exit"
+        cmd = "ssh -oStrictHostKeyChecking=no -oConnectionAttempts=10 -oNumberOfPasswordPrompts=10 #{server} exit"
         @node.vm.provision 'shell', inline: cmd
       end
     end
@@ -223,7 +229,9 @@ module Vagrant
       [ 'all', @host].each do |group|
         unless (@commands[group].nil?) then
           @commands[group].each do |cmd|
-            @node.vm.provision 'shell', inline: cmd
+            unless cmd.nil? then
+              @node.vm.provision 'shell', inline: cmd
+            end
           end
         end
       end

--- a/openSUSE_vagrant_setup.sh
+++ b/openSUSE_vagrant_setup.sh
@@ -5,13 +5,13 @@ set -ex
 zypper_version=($(zypper -V))
 if [[ ${zypper_version[1]} < '1.14.4' ]]
 then
-    zypper --no-gpg-checks in -y https://releases.hashicorp.com/vagrant/2.2.0/vagrant_2.2.0_x86_64.rpm
+    zypper --no-gpg-checks in -y https://releases.hashicorp.com/vagrant/2.2.3/vagrant_2.2.3_x86_64.rpm
 else
-    zypper in -y --allow-unsigned-rpm https://releases.hashicorp.com/vagrant/2.2.0/vagrant_2.2.0_x86_64.rpm
+    zypper in -y --allow-unsigned-rpm https://releases.hashicorp.com/vagrant/2.2.3/vagrant_2.2.3_x86_64.rpm
 fi
 
 # workaround for https://github.com/hashicorp/vagrant/issues/10019
-mv /opt/vagrant/embedded/lib/libreadline.so.7{,.disabled} | true
+#mv /opt/vagrant/embedded/lib/libreadline.so.7{,.disabled} | true
     
 zypper in -y ruby-devel
 zypper in -y gcc gcc-c++ make


### PR DESCRIPTION
This add support for the Kubic with small hacks. Better approach would be to have it as part of #17, but that refactoring is for the future.

This should bring up cluster with k8s up and running, also suse-master branch of rook in /home/vagrant at admin node (k8s master).