### PR TITLE
Doc: added ssh-key section - removed global.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,18 @@ Edit the _Vagrantfile_ and set BOX, INSTALLATION and CONFIGURATION.  Use the fol
 
 Or you could specify BOX as an environment `$ BOX="openSUSE-13.2" vagrant up` / `$ export BOX="openSUSE-13.2"`
 
+Before you can start the environment you need to double check if you can ssh into localhost
+
+`$ ssh root@localhost` 
+
+If that isn't possible please check your /etc/ssh/sshd_config file and change the following option:
+
+`$ PermitRootLogin yes`
+
+Afterwards copy your pub-key by entering
+
+`$ ssh-copy-id root@localhost` 
+
 Start the environment.
 
 `$ vagrant up`

--- a/files/salt/admin/srv/pillar/ceph/stack/global.yml
+++ b/files/salt/admin/srv/pillar/ceph/stack/global.yml
@@ -1,2 +1,0 @@
-stage_prep_minion: default-update-no-reboot
-stage_prep_master: default-update-no-reboot


### PR DESCRIPTION
I added another section to let the user know that they have to enable root login and that they need to be able to login to their system via ssh.

I also removed the global.yaml as the "default-update-no-reboot" is already the default in the meanwhile and this will block stage.0 to run through. 