### PR TITLE
Vagrantfile cwd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .vagrant
 *.sw?
-hosts
 *.box
 tags

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,8 @@ require_relative 'lib/settings.rb'
 require_relative 'lib/hosts.rb'
 require_relative 'lib/provisions.rb'
 
-config_file = 'config.yml'
+config_dir = File.expand_path File.dirname(__FILE__)
+config_file = File.join(config_dir, 'config.yml')
 config = YAML.load_file(config_file)
 
 # Check that the user has an ssh key


### PR DESCRIPTION
Minor polish to handle the current working dir.

- Allow user to change dir outside the Vagrantfile cwd
- Use a Tempfile rather than create a 'host' file in cwd
