### PR TITLE
Change repository ordering for Leap 15.1

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -86,9 +86,9 @@ opensuse/MicroOS-Kubic-kubeadm:
 sub0/leap151:
   salt:
     repos:
-      '15.1': 'http://download.opensuse.org/distribution/leap/15.1/repo/oss/'
-      '15.1 up': 'http://download.opensuse.org/update/leap/15.1/oss/'
       'ceph': 'https://download.opensuse.org/repositories/filesystems:/ceph:/nautilus/openSUSE_Leap_15.1/'
+      '15.1 up': 'http://download.opensuse.org/update/leap/15.1/oss/'
+      '15.1': 'http://download.opensuse.org/distribution/leap/15.1/repo/oss/'
     packages:
       all:
         - vim


### PR DESCRIPTION
Avoid installation issues caused by repository priorities.