### PR TITLE
Change repo order for SLE-15-SP1 to fix priorities

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -321,14 +321,14 @@ SUSE/SLE-12-SP3:
 SUSE/SLE-15-SP1:
   salt:
     repos:
-      'Storage': 'http://download.suse.de/ibs/SUSE/Products/Storage/6/x86_64/product/'
       'Storage up': 'http://download.suse.de/ibs/SUSE/Updates/Storage/6/x86_64/update/'
-      'basesystem': 'http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP1/x86_64/product/'
+      'Storage': 'http://download.suse.de/ibs/SUSE/Products/Storage/6/x86_64/product/'
       'update': 'http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Basesystem/15-SP1/x86_64/update/'
-      'sle server app': 'http://download.suse.de/ibs/SUSE/Products/SLE-Module-Server-Applications/15-SP1/x86_64/product/'
+      'basesystem': 'http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP1/x86_64/product/'
       'sle server app up': 'http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Server-Applications/15-SP1/x86_64/update/'
-      'sle dev_pool': 'http://download.suse.de/ibs/SUSE/Products/SLE-Module-Development-Tools/15-SP1/x86_64/product/'
+      'sle server app': 'http://download.suse.de/ibs/SUSE/Products/SLE-Module-Server-Applications/15-SP1/x86_64/product/'
       'sle dev_tool up': 'http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Development-Tools/15-SP1/x86_64/update/'
+      'sle dev_pool': 'http://download.suse.de/ibs/SUSE/Products/SLE-Module-Development-Tools/15-SP1/x86_64/product/'
     packages:
       all:
         - vim


### PR DESCRIPTION
Current SLE15SP1 installation fails with:

admin: Problem: vim-data-8.0.1568-3.20.noarch requires \
  vim-data-common = 8.0.1568-3.20, but this requirement \
  cannot be provided

The reason is, that the update repository has a lower priority
than the base repository. But vim-data-common is already installed
from the update repository.

This commit changes the order so packages from the updates repos are
taken instead of packages from the base repos.