### PR TITLE
[DNM] Use SES7 Devel repos (will require updates!)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,7 +18,7 @@ config = YAML.load_file(config_file)
 Vagrant::Hosts::check_for_ssh_keys
 
 ### take BOX from the enviroment ###
-BOX = ENV.has_key?('BOX') ? ENV['BOX'] : 'opensuse/openSUSE-42.3-x86_64'
+BOX = ENV.has_key?('BOX') ? ENV['BOX'] : 'SUSE/SLE-15-SP1'
 
 # Set BOX to one of 'Tumbleweed', 'SLE-12'
 #BOX = 'opensuse/openSUSE-42.2-x86_64'
@@ -45,7 +45,7 @@ raise "Configuration #{CONFIGURATION} missing from config.yml" unless config[CON
 # (e.g. vagrant-ceph is default, vsm is another git clone with PREFIX='v'
 # hostnames will be 'vadmin', 'vmon1', etc.  Both sets use same address range
 # and cannot run simultaneously.  Each set will consume disk space. )
-PREFIX = ''
+PREFIX = 'ses7-'
 
 # Generates a hosts file
 if (INSTALLATION == 'salt') then

--- a/config.yml
+++ b/config.yml
@@ -329,6 +329,8 @@ SUSE/SLE-15-SP1:
       'sle server app': 'http://download.suse.de/ibs/SUSE/Products/SLE-Module-Server-Applications/15-SP1/x86_64/product/'
       'sle dev_tool up': 'http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Development-Tools/15-SP1/x86_64/update/'
       'sle dev_pool': 'http://download.suse.de/ibs/SUSE/Products/SLE-Module-Development-Tools/15-SP1/x86_64/product/'
+      'sle containers up': 'http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Containers/15-SP1/x86_64/update/'
+      'sle containers': 'http://download.suse.de/ibs/SUSE/Products/SLE-Module-Containers/15-SP1/x86_64/product/'
     packages:
       all:
         - vim

--- a/config.yml
+++ b/config.yml
@@ -316,13 +316,13 @@ SUSE/SLE-12-SP3:
         - systemctl enable salt-minion
 
 ########################################
-# SLE 15 SP1 SES6
+# SLE 15 SP1 SES7
 ########################################
 SUSE/SLE-15-SP1:
   salt:
     repos:
-      'Storage up': 'http://download.suse.de/ibs/SUSE/Updates/Storage/6/x86_64/update/'
-      'Storage': 'http://download.suse.de/ibs/SUSE/Products/Storage/6/x86_64/product/'
+      'Storage Devel Internal': 'http://download.suse.de/ibs/Devel:/Storage:/7.0/images/repo/SUSE-Enterprise-Storage-7-POOL-Internal-x86_64-Build3.16-Media/'
+      'Storage Devel': 'http://download.suse.de/ibs/Devel:/Storage:/7.0/images/repo/SUSE-Enterprise-Storage-7-POOL-x86_64-Build3.29-Media1/'
       'update': 'http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Basesystem/15-SP1/x86_64/update/'
       'basesystem': 'http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP1/x86_64/product/'
       'sle server app up': 'http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Server-Applications/15-SP1/x86_64/update/'


### PR DESCRIPTION
This defaults to using SLE 15 SP1 plus Devel:Storage:7.0, but note that
the repo URLs in config.yml will be *wrong* next time we get a build,
as the build number increments.  For now, you're best off mirroring
those repos locally somehow then pointing config.yml at your local mirror.

Signed-off-by: Tim Serong <tserong@suse.com>