### PR TITLE
Add optional repository priority override

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -122,7 +122,9 @@ sub0/leap151:
 opensuse/openSUSE-42.3-x86_64:
   salt:
     repos:
-      'ceph': 'http://download.opensuse.org/repositories/filesystems:/ceph:/luminous/openSUSE_Leap_42.3/'
+      'ceph':
+        'url': 'http://download.opensuse.org/repositories/filesystems:/ceph:/luminous/openSUSE_Leap_42.3/'
+        'priority': 1
       '42.3': 'http://download.opensuse.org/distribution/leap/42.3/repo/oss/suse/'
       '42.3 up': 'http://download.opensuse.org/update/leap/42.3/oss/'
       'oA and monitoring': 'https://download.opensuse.org/repositories/filesystems:/openATTIC:/3.x/openSUSE_Leap_42.3/'

--- a/lib/provisions.rb
+++ b/lib/provisions.rb
@@ -11,13 +11,22 @@ module Vagrant
     #
     #   node - vagrant provider
     #   repos - hash of repo names and urls
+    #
+    # repo URLs can either be a string (in which case it's taken to be
+    # the repo URL), or a hash, with members 'url' and 'priority', in
+    # case you need to force a repo to have a specific priority
     def initialize(node, repos)
       @node = node
       @cmds = []
       unless repos.nil? then
-        repos.each_with_index do |(repo,url), index|
+        repos.each do |(repo,url)|
+          priority = 0
+          if url.is_a?(Hash) then
+            priority = url['priority'] || 0
+            url = url['url']
+          end
           # Use shell short circuit to determine if repo already exists
-          @cmds << "zypper lr \'#{repo}\' | grep -sq ^Name || zypper ar -f -p \'#{index.next}\' \'#{url}\' \'#{repo}\'"
+          @cmds << "zypper lr \'#{repo}\' | grep -sq ^Name || zypper ar -f -p \'#{priority}\' \'#{url}\' \'#{repo}\'"
         end
       end
     end


### PR DESCRIPTION
This allows repos to be specified as just `'name': 'url'` (in which case they all get the usual default priority), or if you need to set a specific priority, as:

```
  'name':
    'url': 'url goes here'
    'priority': 1            # or whatever priority you need
```

Fixes: https://github.com/openSUSE/vagrant-ceph/issues/57
Signed-off-by: Tim Serong <tserong@suse.com>