### PR TITLE
Add role-storage to policy.cfg for SLE15SP1 tiny

### DIFF
--- a/files/salt/SLE-15-SP1_tiny/srv/pillar/ceph/proposals/policy.cfg
+++ b/files/salt/SLE-15-SP1_tiny/srv/pillar/ceph/proposals/policy.cfg
@@ -17,4 +17,5 @@ role-mon/cluster/data[1,2,3]*.sls
 role-mon/stack/default/ceph/minions/data[1,2,3]*.yml
 role-mgr/cluster/mon*.sls
 role-mds/cluster/data1*.sls
+role-storage/cluster/data*.sls
 #role-openattic/cluster/mon[1,2]*.sls


### PR DESCRIPTION
There needs to be a storage role assigned to a node. Otherwise the
deployment fails during stage 3 with:

Error description:
  - I@roles:storage and I@cluster:ceph: No minions matched the \
      target. No command was sent, no jid was assigned.