### PR TITLE
Edit Jenkins test results URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Create a vagrant configuration to support multiple ceph cluster topologies.  Ide
 
  Box and Base system | openSUSE 15.1
 --- | --- |
-**sub0/leap151** | [![Build Status](https://ceph-ci.suse.de/job/vagrant-matrix/BOX=sub0%2Fleap151,TARGET_IMAGE=teuthology-opensuse-15.1-x86_64,WORKER_LABEL=storage-compute/badge/icon)](https://ceph-ci.suse.de/job/vagrant-matrix/BOX=sub0%2Fleap151,TARGET_IMAGE=teuthology-opensuse-15.1-x86_64,WORKER_LABEL=storage-compute) |
+**openSUSE Leap 15.1** | [![Build Status](https://ceph-ci.suse.de/job/vagrant-matrix/BOX=virt-appl%2FopenSUSE-Leap-15.1,TARGET_IMAGE=teuthology-opensuse-15.1-x86_64,WORKER_LABEL=storage-compute/badge/icon)](https://ceph-ci.suse.de/job/vagrant-matrix/BOX=virt-appl%2FopenSUSE-Leap-15.1,TARGET_IMAGE=teuthology-opensuse-15.1-x86_64,WORKER_LABEL=storage-compute) |
 
 ## Usage
 Review the config.yml.  All addresses are on private networks.  Each commented section lists the requirements for a configuration and approximate initialization time.

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ Create a vagrant configuration to support multiple ceph cluster topologies.  Ide
 
 [![License: LGPL v3](https://img.shields.io/badge/License-LGPL%20v3-blue.svg)](https://github.com/openSUSE/vagrant-ceph/blob/master/LICENSE)
 
- Box and Base system | openSUSE 15.1
+ Vagrant box & Base system | openSUSE 15.1
 --- | --- |
-**openSUSE Leap 15.1** | [![Build Status](https://ceph-ci.suse.de/job/vagrant-matrix/BOX=virt-appl%2FopenSUSE-Leap-15.1,TARGET_IMAGE=teuthology-opensuse-15.1-x86_64,WORKER_LABEL=storage-compute/badge/icon)](https://ceph-ci.suse.de/job/vagrant-matrix/BOX=virt-appl%2FopenSUSE-Leap-15.1,TARGET_IMAGE=teuthology-opensuse-15.1-x86_64,WORKER_LABEL=storage-compute) |
+**virt-appl/openSUSE-Leap-15.1** | [![Build Status](https://ceph-ci.suse.de/job/vagrant-matrix/BOX=virt-appl%2FopenSUSE-Leap-15.1,TARGET_IMAGE=teuthology-opensuse-15.1-x86_64,WORKER_LABEL=storage-compute/badge/icon)](https://ceph-ci.suse.de/job/vagrant-matrix/BOX=virt-appl%2FopenSUSE-Leap-15.1,TARGET_IMAGE=teuthology-opensuse-15.1-x86_64,WORKER_LABEL=storage-compute) |
 
 ## Usage
 Review the config.yml.  All addresses are on private networks.  Each commented section lists the requirements for a configuration and approximate initialization time.


### PR DESCRIPTION
We now use virt-appl/openSUSE-Leap-15.1 for our openSUSE-based Vagrant box
(https://download.opensuse.org/repositories/Virtualization:/Appliances:/Images:/openSUSE-Leap-15.1/images/Leap-15.1.x86_64-libvirt.box)