### PR TITLE
Install ceph-mon on mon node for SLE-15-SP1_tiny

### DIFF
--- a/files/salt/SLE-15-SP1_tiny/srv/pillar/ceph/proposals/policy.cfg
+++ b/files/salt/SLE-15-SP1_tiny/srv/pillar/ceph/proposals/policy.cfg
@@ -13,8 +13,8 @@ role-admin/cluster/data[1,2,3]*.sls
 role-igw/cluster/data3*.sls
 role-igw/stack/default/ceph/minions/data3*.yml
 role-rgw/cluster/data2*.sls
-role-mon/cluster/data[1,2,3]*.sls
-role-mon/stack/default/ceph/minions/data[1,2,3]*.yml
+role-mon/cluster/mon*.sls
+role-mon/stack/default/ceph/minions/mon*.yml
 role-mgr/cluster/mon*.sls
 role-mds/cluster/data1*.sls
 role-storage/cluster/data*.sls


### PR DESCRIPTION
That's why the node is called mon1 - to have ceph-mon installed. Also
this installs ceph-mon on the same node as ceph-mgr which is
recommended[1]

[1] https://docs.ceph.com/docs/master/mgr/