### PR TITLE
Switch to flannel as CNI when using MicroOS/Kubic

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -75,7 +75,7 @@ opensuse/MicroOS-Kubic-kubeadm:
       admin:
         - getent hosts admin-management | awk '{ print $1}' | xargs kubeadm init --pod-network-cidr=10.244.0.0/16 --token 56fa9a.705a6001db6a6756 --skip-token-print --apiserver-advertise-address 
         - mkdir -p $HOME/.kube; cp -i /etc/kubernetes/admin.conf $HOME/.kube/config; chown $(id -u):$(id -g) $HOME/.kube/config
-        - kubectl apply -f /usr/share/k8s-yaml/cilium/cilium.yaml
+        - kubectl apply -f /usr/share/k8s-yaml/flannel/kube-flannel.yaml
         - kubectl taint nodes admin node-role.kubernetes.io/master:NoSchedule-
       all:
         - ( ( if [ "$HOSTNAME" != "admin" ]; then kubeadm join --token 56fa9a.705a6001db6a6756 --discovery-token-unsafe-skip-ca-verification admin-management:6443 >>/home/vagrant/join 2>&1; fi; ) & )


### PR DESCRIPTION
According to [1], cilium is no longer "supported" (but still there on
best effort base). The CNI of choice is flannel so use that for the
deployment.

[1] https://lists.opensuse.org/opensuse-kubic/2019-10/msg00029.html