### PR TITLE
Add deepsea grain

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -52,6 +52,7 @@ opensuse/Tumbleweed.x86_64:
         #- salt '*' cmd.run 'echo "openSUSE 20181022 (x86_64)" >> /etc/SuSE-release' timeout=10
         - chown -R salt:salt /srv/salt/ceph
         - chown -R salt:salt /srv/pillar/ceph
+        - salt '*' grains.append deepsea default
       all:
         #- systemctl disable firewalld
         #- systemctl stop firewalld
@@ -113,6 +114,7 @@ virt-appl/openSUSE-Leap-15.1:
         - sleep 20
         - salt-key -y -A  || exit 0
         - chown -R salt:salt /srv/pillar/ceph /srv/salt/ceph
+        - salt '*' grains.append deepsea default
       all:
         - systemctl restart salt-minion
         - systemctl enable salt-minion
@@ -286,6 +288,7 @@ SUSE/SLE-15-SP1:
         - sleep 20
         - salt-key -y -A  || exit 0
         - chown -R salt:salt /srv/pillar/ceph /srv/salt/ceph
+        - salt '*' grains.append deepsea default
       all:
         - systemctl restart salt-minion
         - systemctl enable salt-minion


### PR DESCRIPTION
Then installing SES6 vagrant-ceph sets everything up but running any
stages fail because the nodes are expected to be identified via a
deepsea grain.

This patch adds a command to admin node to create this grain with:

 salt '*' grains.append deepsea default

I'm not sure when the grain was required, so only added it to the Leap
15.1 and tumbleweed cases. Please advise if more cases are required (or
I missed something).

Signed-off-by: Matthew Oliver <moliver@suse.com>